### PR TITLE
Fixing issues with arguments with optional values lonely in a command.

### DIFF
--- a/src/GetOptionKit/OptionParser.php
+++ b/src/GetOptionKit/OptionParser.php
@@ -72,9 +72,12 @@ class OptionParser
         if( $arg->containsOptionValue() ) {
             $spec->setValue( $arg->getOptionValue() );
         }
-        elseif( ! $next->isOption() )  {
+        elseif( $next && ! $next->isOption() )  {
             $spec->setValue( $next->arg );
         }
+	    else {
+		    $spec->setValue(true);
+	    }
     }
 
     /* 
@@ -94,7 +97,7 @@ class OptionParser
         if( $arg->containsOptionValue() )
             return true;
 
-        if( ! $arg->containsOptionValue() && ! $next->isEmpty() && ! $next->isOption() )
+	    if( ! $arg->containsOptionValue() && $next && ! $next->isEmpty() && ! $next->isOption() )
             return true;
 
         return false;


### PR DESCRIPTION
This closes #9.

I've added what @dlussky suggested and extended the fix to `takeOptionValue` as well. Lastly, be default the option with no value would get a "null" as value, what makes it behave as if it wasn't set. Thus, I'm setting it to "true" if it's there but there's no value. Does that make sense? Is there another place where this change should be replicated?
