### PR TITLE
Enabling translation of CamelCased properties to hyphenated option names

### DIFF
--- a/src/GetOptionKit/OptionResult.php
+++ b/src/GetOptionKit/OptionResult.php
@@ -50,6 +50,11 @@ class OptionResult
 
     public function __get($key)
     {
+        //verifying if we got a camelCased key: http://stackoverflow.com/a/7599674/102960
+        $parts = preg_split('/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/', $key);
+        if( sizeof($parts) > 1 )
+            $key = join('-', array_map('strtolower', $parts));
+	    
         if( isset($this->keys[ $key ]) )
             return @$this->keys[ $key ]->value;
     }


### PR DESCRIPTION
This way we can have a clear interface for all sorts of options. Currently we can access common options as `$this->options->list` and `$this->options['list']`, but complex names such as `--read-only` can only be accessed using `ArrayAccess`.

With this change we can now also use `$this->options->readOnly` safely :)
