### PR TITLE
Update OptionCollection print API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Print:
 ```php
 use GetOptionKit\OptionCollection;
 use GetOptionKit\OptionParser;
+use GetOptionKit\OptionPrinter\ConsoleOptionPrinter;
 
 $specs = new OptionCollection;
 $specs->add('f|foo:', 'option requires a value.' )
@@ -139,7 +140,9 @@ $specs->add('v|verbose', 'verbose message.' );
 $specs->add('d|debug', 'debug message.' );
 $specs->add('long', 'long option name only.' );
 $specs->add('s', 'short option name only.' );
-$specs->printOptions();
+
+$printer = new ConsoleOptionPrinter();
+echo $printer->render($specs);
 
 $parser = new OptionParser($specs);
 


### PR DESCRIPTION
`$specs->printOptions()` does not exist in the latest API, instead we need to use `echo $printer->render($specs);` with the correct printer.