### PR TITLE
Update OptionParser.php

### DIFF
--- a/src/GetOptionKit/OptionParser.php
+++ b/src/GetOptionKit/OptionParser.php
@@ -71,7 +71,7 @@ class OptionParser
             $spec->setValue($spec->defaultVlaue);
         } else if ($spec->isFlag()) {
             $spec->setValue(true);
-        } else if (!$next->isEmpty()) {
+        } else if ($next && !$next->isEmpty()) {
             $spec->setValue($next->arg);
         } else {
             $spec->setValue(true);
@@ -198,7 +198,7 @@ class OptionParser
             elseif ($spec->isOptional())
             {
                 $this->takeOptionValue($spec,$arg,$next);
-                if (($spec->value || $spec->defaultValue) && ! $next->isOption() ) {
+                if (($spec->value || $spec->defaultValue) && $next && !$next->isOption() ) {
                     $i++;
                 }
                 $result->set( $spec->getId() , $spec);


### PR DESCRIPTION
spec option with optionnal value output fatal error when value(s) missing

$specs->add('z|zoo?', 'option with optional value.');

$ php script.php -z

Fatal error: Call to a member function isEmpty() on null in \vendor\corneltek\getoptionkit\src\GetOptionKit\OptionParser.php on line 74
Fatal error: Call to a member function isOption() on null in \vendor\corneltek\getoptionkit\src\GetOptionKit\OptionParser.php on line 201