### PR TITLE
added value type option(s) support, added class RegexType

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ $opt->add( 'ipv4:' , 'with ipv4 type value' )
 
 $opt->add( 'ipv6:' , 'with ipv6 type value' )
     ->isa('ipv6');
+
+$specs->add('r|regex:', 'with custom regex type value')
+      ->isa('Regex', '/^([a-z]+)$/');
 ```
 
 > Please note that currently only `string`, `number`, `boolean` types can be validated.

--- a/examples/demo.php
+++ b/examples/demo.php
@@ -43,8 +43,8 @@ $specs->add('file:', 'option value should be a file.' )
     })
     ->isa('File');
 
-$specs->add('r|regex', 'option with optional value')
-    ->isa('Regex', '/^([a-z]+)$/');
+$specs->add('r|regex:', 'with custom regex type value')
+      ->isa('Regex', '/^([a-z]+)$/');
 
 $specs->add('d|debug', 'debug message.' );
 $specs->add('long', 'long option name only.' );

--- a/examples/demo.php
+++ b/examples/demo.php
@@ -43,6 +43,9 @@ $specs->add('file:', 'option value should be a file.' )
     })
     ->isa('File');
 
+$specs->add('r|regex', 'option with optional value')
+    ->isa('Regex', '/^([a-z]+)$/');
+
 $specs->add('d|debug', 'debug message.' );
 $specs->add('long', 'long option name only.' );
 $specs->add('s', 'short option name only.' );

--- a/src/GetOptionKit/Argument.php
+++ b/src/GetOptionKit/Argument.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * This file is part of the {{ }} package.
+ * This file is part of the GetOptionKit package.
  *
  * (c) Yo-An Lin <cornelius.howl@gmail.com>
  *

--- a/src/GetOptionKit/Option.php
+++ b/src/GetOptionKit/Option.php
@@ -95,7 +95,7 @@ class Option
                 )?
         )
         ([:+?])?
-        (?:=(string|number|date|file))?
+        (?:=(boolean|string|number|date|file|url|email|ip|ipv6|ipv4))?
         /x';
 
         if( preg_match( $pattern, $specString , $regs ) === false ) {

--- a/src/GetOptionKit/Option.php
+++ b/src/GetOptionKit/Option.php
@@ -42,6 +42,8 @@ class Option
 
     public $isa;
 
+    public $isaOption;
+
     public $validValues;
 
     public $suggestions;
@@ -247,7 +249,7 @@ class Option
     public function getTypeClass() {
         $class = 'GetOptionKit\\ValueType\\' . ucfirst($this->isa) . 'Type';
         if ( class_exists($class, true) ) {
-            return new $class;
+            return new $class($this->isaOption);
         }
         return false;
     }
@@ -428,9 +430,12 @@ class Option
      * @param string $type the value type, valid values are 'number', 'string', 
      *                      'file', 'boolean', you can also use your own value type name.
      *
+     * @param mixed  $option option(s) for value type class (optionnal)
+     *
      */
-    public function isa($type) {
+    public function isa($type, $option = null) {
         $this->isa = $type;
+        $this->isaOption = $option;
         return $this;
     }
 

--- a/src/GetOptionKit/Option.php
+++ b/src/GetOptionKit/Option.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * This file is part of the {{ }} package.
+ * This file is part of the GetOptionKit package.
  *
  * (c) Yo-An Lin <cornelius.howl@gmail.com>
  *

--- a/src/GetOptionKit/ValueType/BaseType.php
+++ b/src/GetOptionKit/ValueType/BaseType.php
@@ -3,9 +3,16 @@ namespace GetOptionKit\ValueType;
 
 abstract class BaseType
 {
-    public function __construct()
+    /**
+     * Type option
+     * 
+     * @var mixed
+     */
+    public $option;
+
+    public function __construct($option = null)
     {
-        // code...
+        if($option) $this->option = $option;
     }
 
     /**
@@ -22,8 +29,3 @@ abstract class BaseType
      */
     abstract public function parse($value);
 }
-
-
-
-
-

--- a/src/GetOptionKit/ValueType/RegexType.php
+++ b/src/GetOptionKit/ValueType/RegexType.php
@@ -6,6 +6,7 @@ class RegexType extends BaseType
     public $matches = [];
 
     public function test($value) { 
+        if(empty($this->option)) return false;
         $pm = preg_match( $this->option, $value);
         if($pm == 0) $pm = false;
         return $pm;

--- a/src/GetOptionKit/ValueType/RegexType.php
+++ b/src/GetOptionKit/ValueType/RegexType.php
@@ -1,0 +1,19 @@
+<?php
+namespace GetOptionKit\ValueType;
+
+class RegexType extends BaseType
+{
+    public $matches = [];
+
+    public function test($value) { 
+        $pm = preg_match( $this->option, $value);
+        if($pm == 0) $pm = false;
+        return $pm;
+    }
+
+    public function parse($value) {
+        return strval($value);
+    }
+}
+
+

--- a/tests/GetOptionKit/ValueTypeTest.php
+++ b/tests/GetOptionKit/ValueTypeTest.php
@@ -8,6 +8,7 @@ use GetOptionKit\ValueType\IpType;
 use GetOptionKit\ValueType\Ipv4Type;
 use GetOptionKit\ValueType\Ipv6Type;
 use GetOptionKit\ValueType\EmailType;
+use GetOptionKit\ValueType\RegexType;
 
 class ValueTypeTest extends PHPUnit_Framework_TestCase
 {
@@ -23,6 +24,7 @@ class ValueTypeTest extends PHPUnit_Framework_TestCase
         ok( new Ipv4Type );
         ok( new Ipv6Type );
         ok( new EmailType );
+        ok( new RegexType );
     }
 
 
@@ -73,6 +75,18 @@ class ValueTypeTest extends PHPUnit_Framework_TestCase
         $email = new EmailType;
         ok( $email->test('test@gmail.com') );
         $this->assertFalse($email->test('test@test'));
+    }
+
+    public function testRegexType()
+    {
+        $regex = new RegexType;
+        $regex->option = '#^Test$#';
+        ok( $regex->test('Test') );
+        $this->assertFalse($regex->test('test'));
+
+        $regex->option = '/^([a-z]+)$/';
+        ok( $regex->test('barfoo') );
+        $this->assertFalse($regex->test('foobar234'));
     }
 }
 


### PR DESCRIPTION
```php
$specs->add('r|regex:', 'with custom regex type value')
      ->isa('Regex', '/^([a-z]+)$/');
```