### PR TITLE
Bug fix. Don't test `':' . $val` for true, test `$val` itself.

### DIFF
--- a/src/GetOptionKit/Option.php
+++ b/src/GetOptionKit/Option.php
@@ -361,7 +361,7 @@ class Option
 
         if ($val = $this->defaultValue) {
             if (is_bool($val)) {
-                $n .= ':' . $val ? 'true' : 'false';
+                $n .= ':' . ($val ? 'true' : 'false');
             } else {
                 $n .= ':' . $this->defaultValue;
             }


### PR DESCRIPTION
This PR corrects a minor bug related to boolean type hints printed by the Option class.

I was seeing strange output in the list of specs; i.e., missing the `:` symbol when printing.

```
--my-option[=<booleantrue>]
```

Should be:

```
--my-option[=<boolean:false>]
```