### PR TITLE
Enable custom validator on Option

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -277,6 +277,10 @@ class Option
             }
         }
 
+        if (!$this->validate($value)[0]) {
+            throw new InvalidOptionValue('option is invalid');
+        }
+
         return $val;
     }
 

--- a/tests/OptionParserTest.php
+++ b/tests/OptionParserTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  */
+use GetOptionKit\InvalidOptionValue;
 use GetOptionKit\OptionCollection;
 use GetOptionKit\OptionParser;
 use GetOptionKit\Option;
@@ -447,5 +448,30 @@ class OptionParserTest extends PHPUnit_Framework_TestCase
         ok( $result->debug );
     }
 
+    public function testParseAcceptsValidOption()
+    {
+        $this->specs
+            ->add('f:foo', 'test option')
+            ->validator(function($value) {
+                return $value === 'valid-option';
+            });
 
+        $result = $this->parser->parse(array('a', '-f' , 'valid-option'));
+
+        $this->assertArrayHasKey('f', $result);
+    }
+
+    /**
+     * @expectedException GetOptionKit\InvalidOptionValue
+     */
+    public function testParseThrowsExceptionOnInvalidOption()
+    {
+        $this->specs
+            ->add('f:foo', 'test option')
+            ->validator(function($value) {
+                return $value === 'valid-option';
+            });
+
+        $this->parser->parse(array('a', '-f' , 'not-a-valid-option'));
+    }
 }


### PR DESCRIPTION
The customer `validator` you could set on an `Option` wasn't triggered during option parsing, this required you to call `$option->validate($option->value))` manually, which is cumbersome and counterintuitive.

Sidenote: I noticed PHPUnit wasn't included as a dependency in `composer.json`, any reason for that? It's hard to run the unit tests that way ;-)