### PR TITLE
added detail about regex when raising an InvalidOptionValue exception

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -266,6 +266,9 @@ class Option
             if ($type->test($value)) {
                 $val = $type->parse($value);
             } else {
+                if (strtolower($isa) === 'regex') {
+                    $isa .= '('.$this->isaOption.')';
+                }
                 throw new InvalidOptionValue("Invalid value for {$this->renderReadableSpec(false)}. Requires a type $isa.");
             }
         }


### PR DESCRIPTION
```php
$specs->add('r|regex:', 'with custom regex type value')
      ->isa('Regex', '/^([a-z]+)$/');
```
```bash
$ command -r 92
```
before:
Invalid value for -h, --regex. Requires a type Regex.
after:
Invalid value for -h, --regex. Requires a type Regex(/^([a-z]+)$/).