### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -123,8 +123,10 @@ class Option
         $this->short = $short;
         $this->long = $long;
 
-        // option is required.
-        if (strpos($attributes, ':') !== false) {
+        if ($attributes === null) {
+            $this->flag();
+        } else if (strpos($attributes, ':') !== false) {
+            // option is required.
             $this->required();
         } else if (strpos($attributes, '+') !== false) {
             // option with multiple value

--- a/src/OptionCollection.php
+++ b/src/OptionCollection.php
@@ -195,11 +195,13 @@ class OptionCollection
         return array_merge(array_keys($this->longOptions), array_keys($this->shortOptions));
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->data);

--- a/src/OptionResult.php
+++ b/src/OptionResult.php
@@ -38,11 +38,13 @@ class OptionResult
     /* arguments */
     public $arguments = array();
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->keys);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->keys);
@@ -106,21 +108,25 @@ class OptionResult
         return array_map(function ($e) { return $e->__toString(); }, $this->arguments);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         $this->keys[ $name ] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return isset($this->keys[ $name ]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->keys[ $name ];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         unset($this->keys[$name]);


### PR DESCRIPTION
- PHP 8.1 deprecated the ability to pass `null` as the haystack to `strpos`.
- Add attribute to non-typehinted interface functions
This could have been fixed by typehinting the functions however to
preserve backwards compatibility to PHP 5.4 this attribute is used
(which is interpreted as a comment in <8.1).
