### PR TITLE
Revert 2bd797f commit & deprecated exception fix

### DIFF
--- a/src/ContinuousOptionParser.php
+++ b/src/ContinuousOptionParser.php
@@ -64,7 +64,7 @@ use GetOptionKit\Exception\RequireValueException;
  *
  *      // command arguments
  *      $arguments = array();
- * 
+ *
  *      $argv = explode(' ','-v -d -c subcommand1 -a -b -c subcommand2 -c subcommand3 arg1 arg2 arg3');
  *
  *      // parse application options first
@@ -139,7 +139,7 @@ class ContinuousOptionParser extends OptionParser
 
     protected function fillDefaultValues(OptionCollection $opts, OptionResult $result)
     {
-        // register option result from options with default value 
+        // register option result from options with default value
         foreach ($opts as $opt) {
             if ($opt->value === null && $opt->defaultValue !== null) {
                 $opt->setValue($opt->getDefaultValue());
@@ -153,7 +153,7 @@ class ContinuousOptionParser extends OptionParser
     {
         // create new Result object.
         $result = new OptionResult();
-        list($this->argv, $extra) = $this->preprocessingArguments($argv);
+        $this->argv = $this->preprocessingArguments($argv);
         $this->length = count($this->argv);
 
         // from last parse index

--- a/src/OptionParser.php
+++ b/src/OptionParser.php
@@ -38,7 +38,7 @@ class OptionParser
      */
     protected function consumeOptionToken(Option $spec, $arg, $next, & $success = false)
     {
-        // Check options doesn't require next token before 
+        // Check options doesn't require next token before
         // all options that require values.
         if ($spec->isFlag()) {
 
@@ -70,11 +70,11 @@ class OptionParser
             $spec->setValue($next->arg);
             return 1;
 
-        } 
+        }
         return 0;
     }
 
-    /* 
+    /*
      * push value to multipl value option
      */
     protected function pushOptionValue(Option $spec, $arg, $next)
@@ -94,7 +94,6 @@ class OptionParser
     {
         // preprocessing arguments
         $newArgv = array();
-        $extra = array();
         $afterDash = false;
         foreach ($argv as $arg) {
             if ($arg === '--') {
@@ -102,7 +101,7 @@ class OptionParser
                 continue;
             }
             if ($afterDash) {
-                $extra[] = $arg;
+                $newArgv[] = $arg;
                 continue;
             }
 
@@ -111,15 +110,15 @@ class OptionParser
                 list($opt, $val) = $a->splitAsOption();
                 array_push($newArgv, $opt, $val);
             } else {
-                $newArgv[] = $arg;
+                array_push($newArgv, $arg);
             }
         }
-        return array($newArgv, $extra);
+        return $newArgv;
     }
 
     protected function fillDefaultValues(OptionCollection $opts, OptionResult $result)
     {
-        // register option result from options with default value 
+        // register option result from options with default value
         foreach ($opts as $opt) {
             if ($opt->value === null && $opt->defaultValue !== null) {
                 $opt->setValue($opt->getDefaultValue());
@@ -141,7 +140,7 @@ class OptionParser
     {
         $result = new OptionResult();
 
-        list($argv, $extra) = $this->preprocessingArguments($argv);
+        $argv = $this->preprocessingArguments($argv);
 
         $len = count($argv);
 

--- a/tests/ContinuousOptionParserTest.php
+++ b/tests/ContinuousOptionParserTest.php
@@ -46,7 +46,7 @@ class ContinuousOptionParserTest extends \PHPUnit\Framework\TestCase
                 ['program','-v', '-c', 'subcommand1', '--as', 99, 'arg1', 'arg2', 'arg3', '--','zz','xx','vv'],
                 [
                     'app' => ['verbose' => true],
-                    'args' => ['arg1', 'arg2', 'arg3']
+                    'args' => ['arg1', 'arg2', 'arg3', 'zz', 'xx', 'vv']
                 ],
             ],
         ];
@@ -203,7 +203,7 @@ class ContinuousOptionParserTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull( $r );
 
 
-        
+
         $this->assertNotNull( $r->a , 'option a' );
         $this->assertNotNull( $r->b , 'option b' );
         $this->assertNotNull( $r->c , 'option c' );
@@ -250,7 +250,7 @@ class ContinuousOptionParserTest extends \PHPUnit\Framework\TestCase
                 $arguments[] = $parser->advance();
             }
         }
-        
+
         $this->assertEquals( 'arg1', $arguments[0] );
         $this->assertEquals( 'arg2', $arguments[1] );
         $this->assertEquals( 'arg3', $arguments[2] );
@@ -261,11 +261,10 @@ class ContinuousOptionParserTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull( 3, $subcommand_options['subcommand3']->a );
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\InvalidOptionException
-     */
     public function testParseInvalidOptionException()
     {
+        $this->expectException(\GetOptionKit\Exception\InvalidOptionException::class);
+
         $parser = new ContinuousOptionParser(new OptionCollection);
         $parser->parse(array('app','--foo'));
         $arguments = array();
@@ -307,23 +306,20 @@ class ContinuousOptionParserTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, $result->keys["verbose"]->value);
     }
 
-
-    /**
-     * @expectedException GetOptionKit\Exception\InvalidOptionException
-     */
     public function testUnknownOption()
     {
+        $this->expectException(\GetOptionKit\Exception\InvalidOptionException::class);
+
         $options = new OptionCollection;
         $options->add("v|verbose");
         $parser = new ContinuousOptionParser($options);
         $result = $parser->parse(array('app', '-b'));
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testAdvancedOutOfBounds()
     {
+        $this->expectException(\LogicException::class);
+
         $options = new OptionCollection;
         $options->add("v|verbose");
         $parser = new ContinuousOptionParser($options);

--- a/tests/OptionCollectionTest.php
+++ b/tests/OptionCollectionTest.php
@@ -12,32 +12,28 @@ class OptionCollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($o, $opts->getShortOption('v'));
     }
 
-
-    /**
-     * @expectedException LogicException
-     */
     public function testAddInvalidOption()
     {
+        $this->expectException(\LogicException::class);
+
         $opts = new OptionCollection;
         $opts->add(123);
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\OptionConflictException
-     */
     public function testOptionConflictShort()
     {
+        $this->expectException(\GetOptionKit\Exception\OptionConflictException::class);
+
         $opts = new OptionCollection;
         $opts->add('r|repeat');
         $opts->add('t|time');
         $opts->add('r|regex');
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\OptionConflictException
-     */
     public function testOptionConflictLong()
     {
+        $this->expectException(\GetOptionKit\Exception\OptionConflictException::class);
+
         $opts = new OptionCollection;
         $opts->add('r|repeat');
         $opts->add('t|time');

--- a/tests/OptionParserTest.php
+++ b/tests/OptionParserTest.php
@@ -24,11 +24,10 @@ class OptionParserTest extends \PHPUnit\Framework\TestCase
         $this->parser = new OptionParser($this->specs);
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testInvalidOption()
     {
+        $this->expectException(\Exception::class);
+
         $options = new OptionCollection;
         $options->addOption(new Option(0));
     }
@@ -229,17 +228,16 @@ class OptionParserTest extends \PHPUnit\Framework\TestCase
 
         $parser = new OptionParser($opts);
         $result = $parser->parse(explode(' ','app -vvv arg1 arg2'));
-        $this->assertInstanceOf('GetOptionKit\Option',$result['verbose']); 
+        $this->assertInstanceOf('GetOptionKit\Option',$result['verbose']);
         $this->assertNotNull($result['verbose']);
         $this->assertEquals(3, $result['verbose']->value);
     }
 
 
-    /**
-     * @expectedException Exception
-     */
     public function testIntegerTypeNonNumeric()
     {
+        $this->expectException(\Exception::class);
+
         $opt = new OptionCollection;
         $opt->add( 'b|bar:=number' , 'option with integer type' );
 
@@ -350,13 +348,13 @@ class OptionParserTest extends \PHPUnit\Framework\TestCase
                 [['a','--foo','a', 'b', 'c']]
             ),
             array( 'f|foo', 'simple boolean option', 'foo', true,
-                [['a','--foo'], ['a','-f']] 
+                [['a','--foo'], ['a','-f']]
             ),
             array( 'f|foo:=string', 'string option', 'foo', 'xxx',
-                [['a','--foo','xxx'], ['a','-f', 'xxx']] 
+                [['a','--foo','xxx'], ['a','-f', 'xxx']]
             ),
             array( 'f|foo:=string', 'string option', 'foo', 'xxx',
-                [['a','b', 'c', '--foo','xxx'], ['a', 'a', 'b', 'c', '-f', 'xxx']] 
+                [['a','b', 'c', '--foo','xxx'], ['a', 'a', 'b', 'c', '-f', 'xxx']]
             ),
         );
     }
@@ -375,29 +373,26 @@ class OptionParserTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testParseWithoutProgramName()
     {
+        $this->expectException(\Exception::class);
+
         $parser = new OptionParser(new OptionCollection);
         $parser->parse(array('--foo'));
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\InvalidOptionException
-     */
     public function testParseInvalidOptionException()
     {
+        $this->expectException(\GetOptionKit\Exception\InvalidOptionException::class);
+
         $parser = new OptionParser(new OptionCollection);
         $parser->parse(array('app','--foo'));
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\RequireValueException
-     */
     public function testParseOptionRequireValueException()
     {
+        $this->expectException(\GetOptionKit\Exception\RequireValueException::class);
+
         $options = new OptionCollection;
         $options->add('name:=string', 'name');
 
@@ -461,11 +456,10 @@ class OptionParserTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('f', $result);
     }
 
-    /**
-     * @expectedException GetOptionKit\Exception\InvalidOptionValueException
-     */
     public function testParseThrowsExceptionOnInvalidOption()
     {
+        $this->expectException(\GetOptionKit\Exception\InvalidOptionValueException::class);
+
         $this->specs
             ->add('f:foo', 'test option')
             ->validator(function($value) {

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -27,11 +27,10 @@ class OptionTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($opt);
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testInvalidOptionSpec()
     {
+        $this->expectException(\Exception::class);
+
         new Option('....');
     }
 
@@ -87,21 +86,19 @@ class OptionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('--scope', $opt->renderReadableSpec(true));
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testInvalidTypeClass()
     {
+        $this->expectException(\Exception::class);
+
         $opt = new Option('scope');
         $opt->isa('SomethingElse');
         $class = $opt->getTypeClass();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testValidatorReturnValue()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $opt = new Option('scope');
         $opt->validator(function($val) {
             return 123454;
@@ -216,7 +213,7 @@ class OptionTest extends \PHPUnit\Framework\TestCase
 
     public function testFilter() {
         $opt = new Option('scope');
-        $opt->filter(function($val) { 
+        $opt->filter(function($val) {
             return preg_replace('#a#', 'x', $val);
         })
         ;


### PR DESCRIPTION
# Changed log

- Reverting the 2bd797f commit because the commit is not fixed for extra argument parsing. And it needs to fall back.
- Since the `@expectedException` comment annotation is deprecated in the latest PHPUnit version, using the `expectException` method instead.